### PR TITLE
Part 4 for MATLAB

### DIFF
--- a/MATLAB/Layer_Dense.m
+++ b/MATLAB/Layer_Dense.m
@@ -1,0 +1,36 @@
+% Definition of the Layer_Dense class
+%   This file must be in the same directory (or path) as the script using
+%   the Layer_Dense class
+% 
+% Constructor:  Requires: number of input features to the layer,
+%                         number of neurons in the layer
+%               Modifies: N/A
+%               Returns : the Layer_Dense object with intial weights and
+%                           biases
+% 
+% forward:  Requires: Layer_Dense object to be modified,
+%                     inputs to the layer
+%           Modifies: output
+%           Returns : the updated Layer_Dense object
+
+
+classdef Layer_Dense
+    properties
+        weights
+        biases
+        output
+    end
+    
+    methods
+        function layer = Layer_Dense(n_inputs, n_neurons)
+            if nargin < 2, error('Initialization requires input and layer size'); end
+            
+            layer.weights = 0.10 * rand(n_inputs, n_neurons);
+            layer.biases = zeros(1, n_neurons);
+        end
+        
+        function layer = forward(layer, inputs)
+            layer.output = inputs * layer.weights + layer.biases;
+        end
+    end
+end

--- a/MATLAB/p004_Batches_Layers_and_Objects.m
+++ b/MATLAB/p004_Batches_Layers_and_Objects.m
@@ -1,0 +1,23 @@
+% Associated YT NNFS tutorial: https://youtu.be/TEWy9vZcxW4
+%   Part 004: Batches, Layers, and Objects
+% 
+%   NOTE: This script requires the class definition files to be in the same
+%   directory (i.e. Layer_Dense.m). See that file for information on MATLAB
+%   class usage
+
+rng(0)
+
+% Define input feature sets
+X = [ 1,    2,    3,    2.5
+      2.0,  5.0, -1.0,  2.0
+     -1.5,  2.7,  3.3, -0.8];
+
+% Initialize layers
+layer1 = Layer_Dense(4, 5);
+layer2 = Layer_Dense(5, 2);
+
+% Perform forward pass through the neural network
+layer1 = forward(layer1, X);
+%disp(layer1.output)
+layer2 = forward(layer2, layer1.output);
+disp(layer2.output)


### PR DESCRIPTION
Sets up a Layer_Dense class in MATLAB to be used with the included main script. Separate files are needed due to MATLAB handling of class definitions. Script and class parallel the Python version of the tutorial.